### PR TITLE
On start of service create the /var/run/cube.

### DIFF
--- a/templates/cube-collector
+++ b/templates/cube-collector
@@ -9,6 +9,7 @@ GROUP="cube"
 
 start() {
 	echo "Starting $NAME..."
+	mkdir -p /var/run/cube
 	start-stop-daemon --background --make-pidfile --pidfile $PIDFILE -o --chuid $USER:$GROUP --start --exec "$APP_DIR/$APP_BIN" -- $APP_ARGS
 }
  

--- a/templates/cube-evaluator
+++ b/templates/cube-evaluator
@@ -9,6 +9,7 @@ GROUP="cube"
 
 start() {
 	echo "Starting $NAME..."
+	mkdir -p /var/run/cube
 	start-stop-daemon --background --make-pidfile --pidfile $PIDFILE -o --chuid $USER:$GROUP --start --exec "$APP_DIR/$APP_BIN" -- $APP_ARGS
 }
  


### PR DESCRIPTION
On some systems, /var/run is deleted on reboot. If it does not exist, these scripts will fail to start the cube programs.
See http://askubuntu.com/questions/303120/how-folders-created-in-var-run-on-each-reboot.
